### PR TITLE
Change student uniqueness check to `StudentId`

### DIFF
--- a/src/main/java/jeryl/fyp/logic/commands/EditCommand.java
+++ b/src/main/java/jeryl/fyp/logic/commands/EditCommand.java
@@ -78,7 +78,7 @@ public class EditCommand extends Command {
         Student studentToEdit = lastShownList.get(index.getZeroBased());
         Student editedStudent = createEditedStudent(studentToEdit, editStudentDescriptor);
 
-        if (!studentToEdit.isSameStudentName(editedStudent) && model.hasStudent(editedStudent)) {
+        if (!studentToEdit.isSameStudentId(editedStudent) && model.hasStudent(editedStudent)) {
             throw new CommandException(MESSAGE_DUPLICATE_STUDENT);
         }
 

--- a/src/main/java/jeryl/fyp/model/student/Student.java
+++ b/src/main/java/jeryl/fyp/model/student/Student.java
@@ -80,17 +80,18 @@ public class Student {
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
     }
+
     /**
-     * Returns true if both students have the same name.
+     * Returns true if both students have the same ID.
      * This defines a weaker notion of equality between two students.
      */
-    public boolean isSameStudentName(Student otherStudent) {
+    public boolean isSameStudentId(Student otherStudent) {
         if (otherStudent == this) {
             return true;
         }
 
         return otherStudent != null
-                && otherStudent.getStudentName().equals(getStudentName());
+                && otherStudent.getStudentId().equals(getStudentId());
     }
 
     /**

--- a/src/main/java/jeryl/fyp/model/student/UniqueStudentList.java
+++ b/src/main/java/jeryl/fyp/model/student/UniqueStudentList.java
@@ -22,7 +22,7 @@ import jeryl.fyp.model.student.exceptions.StudentNotFoundException;
  *
  * Supports a minimal set of list operations.
  *
- * @see Student#isSameStudentName(Student)
+ * @see Student#isSameStudentId(Student)
  */
 public class UniqueStudentList implements Iterable<Student> {
 
@@ -35,7 +35,7 @@ public class UniqueStudentList implements Iterable<Student> {
      */
     public boolean contains(Student toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameStudentName);
+        return internalList.stream().anyMatch(toCheck::isSameStudentId);
     }
 
     /**
@@ -63,7 +63,7 @@ public class UniqueStudentList implements Iterable<Student> {
             throw new StudentNotFoundException();
         }
 
-        if (!target.isSameStudentName(editedStudent) && contains(editedStudent)) {
+        if (!target.isSameStudentId(editedStudent) && contains(editedStudent)) {
             throw new DuplicateStudentException();
         }
 
@@ -136,7 +136,7 @@ public class UniqueStudentList implements Iterable<Student> {
     private boolean studentsAreUnique(List<Student> students) {
         for (int i = 0; i < students.size(); i++) {
             for (int j = i + 1; j < students.size(); j++) {
-                if (students.get(i).isSameStudentName(students.get(j))) {
+                if (students.get(i).isSameStudentId(students.get(j))) {
                     return false;
                 }
             }

--- a/src/test/java/jeryl/fyp/logic/commands/AddStudentCommandTest.java
+++ b/src/test/java/jeryl/fyp/logic/commands/AddStudentCommandTest.java
@@ -208,7 +208,7 @@ public class AddStudentCommandTest {
         @Override
         public boolean hasStudent(Student student) {
             requireNonNull(student);
-            return this.student.isSameStudentName(student);
+            return this.student.isSameStudentId(student);
         }
     }
 
@@ -221,7 +221,7 @@ public class AddStudentCommandTest {
         @Override
         public boolean hasStudent(Student student) {
             requireNonNull(student);
-            return studentsAdded.stream().anyMatch(student::isSameStudentName);
+            return studentsAdded.stream().anyMatch(student::isSameStudentId);
         }
 
         @Override

--- a/src/test/java/jeryl/fyp/model/student/StudentTest.java
+++ b/src/test/java/jeryl/fyp/model/student/StudentTest.java
@@ -24,30 +24,24 @@ public class StudentTest {
     }
 
     @Test
-    public void isSameStudent() {
+    public void isSameStudentId() {
         // same object -> returns true
-        assertTrue(ALICE.isSameStudentName(ALICE));
+        assertTrue(ALICE.isSameStudentId(ALICE));
 
         // null -> returns false
-        assertFalse(ALICE.isSameStudentName(null));
+        assertFalse(ALICE.isSameStudentId(null));
 
-        // same name, all other attributes different -> returns true
-        Student editedAlice = new StudentBuilder(ALICE).withStudentId(VALID_STUDENT_ID_BOB).withEmail(VALID_EMAIL_BOB)
-                .withProjectName(VALID_PROJECT_NAME_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSameStudentName(editedAlice));
+        // same ID, all other attributes different -> returns true
+        Student editedAlice = new StudentBuilder(ALICE)
+                .withStudentName(VALID_STUDENT_NAME_BOB)
+                .withEmail(VALID_EMAIL_BOB)
+                .withProjectName(VALID_PROJECT_NAME_BOB)
+                .withTags(VALID_TAG_HUSBAND).build();
+        assertTrue(ALICE.isSameStudentId(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new StudentBuilder(ALICE).withStudentName(VALID_STUDENT_NAME_BOB).build();
-        assertFalse(ALICE.isSameStudentName(editedAlice));
-
-        // name differs in case, all other attributes same -> returns false
-        Student editedBob = new StudentBuilder(BOB).withStudentName(VALID_STUDENT_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameStudentName(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_STUDENT_NAME_BOB + " ";
-        editedBob = new StudentBuilder(BOB).withStudentName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameStudentName(editedBob));
+        // different ID, all other attributes same -> returns false
+        editedAlice = new StudentBuilder(ALICE).withStudentId(VALID_STUDENT_ID_BOB).build();
+        assertFalse(ALICE.isSameStudentId(editedAlice));
     }
 
     @Test


### PR DESCRIPTION
It makes more sense to check uniqueness based on ID rather than the name since it's very possible to have two students with the same name but different individuals in real life.

This issue closes #132.