### PR TITLE
Increase test coverage for FindCommand

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -327,7 +327,7 @@ Example:
 
 * `add -d i/A0123456G n/Random Task d/23-10-2022 23:59`
 
-#### 3.3.2 Removing a student's deadline: `delete -d`
+#### 3.3.2. Removing a student's deadline: `delete -d`
 
 Removes a deadline assigned to a student specified by ID & a priority rank (Below highlighted task has a priority rank of 2). The specified deadline must exist in the student's deadline list previously.
 ![Priority](images/Priority.png) <br>

--- a/src/test/java/jeryl/fyp/logic/commands/FindProjectNameCommandTest.java
+++ b/src/test/java/jeryl/fyp/logic/commands/FindProjectNameCommandTest.java
@@ -2,7 +2,10 @@ package jeryl.fyp.logic.commands;
 
 import static jeryl.fyp.commons.core.Messages.MESSAGE_PROJECTS_LISTED_OVERVIEW;
 import static jeryl.fyp.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static jeryl.fyp.testutil.TypicalStudents.ALICE;
 import static jeryl.fyp.testutil.TypicalStudents.CARL;
+import static jeryl.fyp.testutil.TypicalStudents.DANIEL;
+import static jeryl.fyp.testutil.TypicalStudents.ELLE;
 import static jeryl.fyp.testutil.TypicalStudents.FIONA;
 import static jeryl.fyp.testutil.TypicalStudents.getTypicalFypManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,7 +67,37 @@ public class FindProjectNameCommandTest {
     }
 
     @Test
+    public void execute_singleKeyword_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 4);
+        ProjectNameContainsKeywordsPredicate predicate = preparePredicate("in");
+        FindProjectNameCommand command = new FindProjectNameCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, DANIEL, ELLE, FIONA), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_noStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 0);
+        ProjectNameContainsKeywordsPredicate predicate = preparePredicate("chemiStRy /  Blockchain");
+        FindProjectNameCommand command = new FindProjectNameCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+    }
+
+    @Test
     public void execute_multipleKeywords_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 3);
+        ProjectNameContainsKeywordsPredicate predicate = preparePredicate("de/ woRld/ Mathematics ");
+        FindProjectNameCommand command = new FindProjectNameCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, DANIEL, FIONA), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_duplicateKeywords_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 2);
         ProjectNameContainsKeywordsPredicate predicate = preparePredicate("de/ woRld/ de ");
         FindProjectNameCommand command = new FindProjectNameCommand(predicate);
@@ -72,7 +105,6 @@ public class FindProjectNameCommandTest {
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, FIONA), model.getFilteredStudentList());
     }
-
     /**
      * Parses {@code userInput} into a {@code ProjectNameContainsKeywordsPredicate}.
      */

--- a/src/test/java/jeryl/fyp/logic/commands/FindStudentIdCommandTest.java
+++ b/src/test/java/jeryl/fyp/logic/commands/FindStudentIdCommandTest.java
@@ -2,8 +2,13 @@ package jeryl.fyp.logic.commands;
 
 import static jeryl.fyp.commons.core.Messages.MESSAGE_PROJECTS_LISTED_OVERVIEW;
 import static jeryl.fyp.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static jeryl.fyp.testutil.TypicalStudents.ALICE;
+import static jeryl.fyp.testutil.TypicalStudents.BENSON;
 import static jeryl.fyp.testutil.TypicalStudents.CARL;
+import static jeryl.fyp.testutil.TypicalStudents.DANIEL;
+import static jeryl.fyp.testutil.TypicalStudents.ELLE;
 import static jeryl.fyp.testutil.TypicalStudents.FIONA;
+import static jeryl.fyp.testutil.TypicalStudents.GEORGE;
 import static jeryl.fyp.testutil.TypicalStudents.getTypicalFypManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -62,6 +67,25 @@ public class FindStudentIdCommandTest {
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredStudentList());
     }
+    @Test
+    public void execute_singleKeyword_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 3);
+        StudentIdContainsKeywordsPredicate predicate = preparePredicate("14");
+        FindStudentIdCommand command = new FindStudentIdCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ELLE, FIONA, GEORGE), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_noStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 0);
+        StudentIdContainsKeywordsPredicate predicate = preparePredicate("123 /  456 / 7890");
+        FindStudentIdCommand command = new FindStudentIdCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+    }
 
     @Test
     public void execute_multipleKeywords_multipleStudentsFound() {
@@ -71,6 +95,28 @@ public class FindStudentIdCommandTest {
         expectedModel.updateFilteredStudentList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, FIONA), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_duplicateKeywords_singleStudentFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 1);
+        StudentIdContainsKeywordsPredicate predicate = preparePredicate("2427  / 2427");
+        FindStudentIdCommand command = new FindStudentIdCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(FIONA), model.getFilteredStudentList());
+    }
+
+    // to address Issue #176, where "find -i/a" will function the same as List
+    // since all StudentId begins with "A"
+    @Test
+    public void execute_keywordContainsA_allStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 7);
+        StudentIdContainsKeywordsPredicate predicate = preparePredicate("a");
+        FindStudentIdCommand command = new FindStudentIdCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE), model.getFilteredStudentList());
     }
 
     /**

--- a/src/test/java/jeryl/fyp/logic/commands/FindStudentNameCommandTest.java
+++ b/src/test/java/jeryl/fyp/logic/commands/FindStudentNameCommandTest.java
@@ -2,7 +2,9 @@ package jeryl.fyp.logic.commands;
 
 import static jeryl.fyp.commons.core.Messages.MESSAGE_PROJECTS_LISTED_OVERVIEW;
 import static jeryl.fyp.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static jeryl.fyp.testutil.TypicalStudents.BENSON;
 import static jeryl.fyp.testutil.TypicalStudents.CARL;
+import static jeryl.fyp.testutil.TypicalStudents.DANIEL;
 import static jeryl.fyp.testutil.TypicalStudents.FIONA;
 import static jeryl.fyp.testutil.TypicalStudents.getTypicalFypManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,6 +66,26 @@ public class FindStudentNameCommandTest {
     }
 
     @Test
+    public void execute_singleKeyword_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 2);
+        StudentNameContainsKeywordsPredicate predicate = preparePredicate("Meier");
+        FindStudentNameCommand command = new FindStudentNameCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_noStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 0);
+        StudentNameContainsKeywordsPredicate predicate = preparePredicate("Ivory   / Trevor");
+        FindStudentNameCommand command = new FindStudentNameCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+    }
+
+    @Test
     public void execute_multipleKeywords_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 2);
         StudentNameContainsKeywordsPredicate predicate = preparePredicate("ku  / kurz / IoN ");
@@ -71,6 +93,16 @@ public class FindStudentNameCommandTest {
         expectedModel.updateFilteredStudentList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, FIONA), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_duplicateKeywords_singleStudentFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 1);
+        StudentNameContainsKeywordsPredicate predicate = preparePredicate("Kunz / Kunz");
+        FindStudentNameCommand command = new FindStudentNameCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(FIONA), model.getFilteredStudentList());
     }
 
     /**

--- a/src/test/java/jeryl/fyp/logic/commands/FindTagsCommandTest.java
+++ b/src/test/java/jeryl/fyp/logic/commands/FindTagsCommandTest.java
@@ -2,7 +2,9 @@ package jeryl.fyp.logic.commands;
 
 import static jeryl.fyp.commons.core.Messages.MESSAGE_PROJECTS_LISTED_OVERVIEW;
 import static jeryl.fyp.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static jeryl.fyp.testutil.TypicalStudents.ALICE;
 import static jeryl.fyp.testutil.TypicalStudents.BENSON;
+import static jeryl.fyp.testutil.TypicalStudents.DANIEL;
 import static jeryl.fyp.testutil.TypicalStudents.getTypicalFypManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -63,6 +65,26 @@ public class FindTagsCommandTest {
     }
 
     @Test
+    public void execute_singleKeyword_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 3);
+        TagsContainKeywordsPredicate predicate = preparePredicate("frIENDs");
+        FindTagsCommand command = new FindTagsCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_noStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 0);
+        TagsContainKeywordsPredicate predicate = preparePredicate("enemies / bffs4lyfe / friendss");
+        FindTagsCommand command = new FindTagsCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredStudentList());
+    }
+
+    @Test
     public void execute_multipleKeywords_multipleStudentsFound() {
         String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 1);
         TagsContainKeywordsPredicate predicate = preparePredicate("smo / wES");
@@ -70,6 +92,16 @@ public class FindTagsCommandTest {
         expectedModel.updateFilteredStudentList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(BENSON), model.getFilteredStudentList());
+    }
+
+    @Test
+    public void execute_duplicateKeywords_multipleStudentsFound() {
+        String expectedMessage = String.format(MESSAGE_PROJECTS_LISTED_OVERVIEW, 3);
+        TagsContainKeywordsPredicate predicate = preparePredicate("friends /  friends");
+        FindTagsCommand command = new FindTagsCommand(predicate);
+        expectedModel.updateFilteredStudentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredStudentList());
     }
 
     /**


### PR DESCRIPTION
- Include more test cases for each of the four subclasses of FindCommand
- Address earlier (closed) issue #176 to test for interesting input of "find -i/a"
- Fix issue #228 as well